### PR TITLE
feat: add support for SOMA Shade 2 devices

### DIFF
--- a/lib/ScAccessory.js
+++ b/lib/ScAccessory.js
@@ -34,6 +34,7 @@ class ScAccessory extends homebridgeLib.AccessoryDelegate {
 
   static get Bridge () { return SomaConnect }
   static get Tilt2 () { return SomaTilt2 }
+  static get Shade2 () { return SomaShade2 }
 }
 
 class SomaConnect extends homebridgeLib.AccessoryDelegate {
@@ -133,6 +134,14 @@ class SomaConnect extends homebridgeLib.AccessoryDelegate {
                 })
               }
               break
+            case 'shade':
+              if (this.shades[id] == null) {
+                this.addShade2(id, {
+                  id: id,
+                  name: shade.name,
+                  firmware: this.values.firmware
+                })
+              }
             default:
               break
           }
@@ -171,12 +180,26 @@ class SomaConnect extends homebridgeLib.AccessoryDelegate {
   addTilt2 (id, context) {
     this.shades[id] = new ScAccessory.Tilt2(this, context)
   }
+
+  addShade2 (id, context) {
+    this.shades[id] = new ScAccessory.Shade2(this, context)
+  }
 }
 
 class SomaTilt2 extends ScAccessory {
   constructor (bridge, params) {
     params.category = bridge.platform.Accessory.Categories.WINDOW_COVERING
     params.model = 'SOMA Tilt 2'
+    super(bridge, params)
+    this.service = new ScService.WindowCovering(this)
+    this.batteryService = new homebridgeLib.ServiceDelegate.Battery(this)
+  }
+}
+
+class SomaShade2 extends ScAccessory {
+  constructor (bridge, params) {
+    params.category = bridge.platform.Accessory.Categories.WINDOW_COVERING
+    params.model = 'SOMA Shade 2'
     super(bridge, params)
     this.service = new ScService.WindowCovering(this)
     this.batteryService = new homebridgeLib.ServiceDelegate.Battery(this)

--- a/lib/ScService.js
+++ b/lib/ScService.js
@@ -80,16 +80,21 @@ class WindowCovering extends homebridgeLib.ServiceDelegate {
       Characteristic: this.Characteristics.hap.PositionState,
       value: this.Characteristics.hap.PositionState.STOPPED
     })
-    this.addCharacteristicDelegate({
-      key: 'closeUpwards',
-      Characteristic: this.Characteristics.my.CloseUpwards,
-      value: false
-    }).on('didSet', async (value, fromHomeKit) => {
-      if (!fromHomeKit) {
-        return
-      }
-      this.setShadePosition()
-    })
+
+    // Only the Tilt 2 can close upwards
+    if (this.model === 'SOMA Tilt 2') {
+      this.addCharacteristicDelegate({
+        key: 'closeUpwards',
+        Characteristic: this.Characteristics.my.CloseUpwards,
+        value: false
+      }).on('didSet', async (value, fromHomeKit) => {
+        if (!fromHomeKit) {
+          return
+        }
+        this.setShadePosition()
+      })
+    }
+
     this.addCharacteristicDelegate({
       key: 'morningMode',
       Characteristic: this.Characteristics.my.MorningMode,
@@ -139,7 +144,7 @@ class WindowCovering extends homebridgeLib.ServiceDelegate {
     position = 100 - position // % open --> % closed
     this.values.currentPosition = position
     if (this.timer == null) {
-      if (this.values.position !== 0) {
+      if (this.values.position !== 0 && this.model === 'SOMA Tilt 2') {
         this.values.closeUpwards = this.values.position < 0
       }
       this.values.targetPosition = position


### PR DESCRIPTION
Which have almost the identical API to the Tilt but do not support the closeUpwards option.

This is just proof-of-concept code to verfy my theory that your plugin would work if the closeUpwards characteristic was suppressed and it does. Feel free to close this PR and reimplement the support in another way, if you prefer.

Signed-off-by: Avi Miller <me@dje.li>